### PR TITLE
Change hash to keyword args using the double splat

### DIFF
--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -26,7 +26,7 @@ module InfluxDB
       )
         query = builder.build(query, params)
 
-        url = full_url("/query".freeze, query_params(query, opts))
+        url = full_url("/query".freeze, query_params(query, **opts))
         series = fetch_series(get(url, parse: true, json_streaming: !chunk_size.nil?))
 
         if block_given?


### PR DESCRIPTION
Change hash to keyword args using the double splat.

```
influxdb-0.8.0/lib/influxdb/query/core.rb:29: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
influxdb-0.8.0/lib/influxdb/query/core.rb:88: warning: The called method `query_params' is defined here
```